### PR TITLE
Adds a get-field-by-index method for ExtendedBedEntry

### DIFF
--- a/src/main/kotlin/org/jetbrains/bio/big/Bed.kt
+++ b/src/main/kotlin/org/jetbrains/bio/big/Bed.kt
@@ -383,7 +383,7 @@ data class ExtendedBedEntry(
                 9 -> blockCount
                 10 -> blockSizes
                 11 -> blockStarts
-                else -> null // should never happen
+                else -> null
             }
         }
     }

--- a/src/main/kotlin/org/jetbrains/bio/big/Bed.kt
+++ b/src/main/kotlin/org/jetbrains/bio/big/Bed.kt
@@ -358,10 +358,18 @@ data class ExtendedBedEntry(
         return rest
     }
 
-    fun getFieldByIndex(i: Int, fieldsNumber: Int, extraFieldsNumber: Int): Any? {
+    /**
+     * Returns a i-th field of a Bed entry. Since ExtendedBedEntry is format-agnostic,
+     * it doesn't actually know which field is i-th, so we have to provide [fieldsNumber] and [extraFieldsNumber].
+     * Returns an instance of a correct type ([Int], [String] etc.) or null for missing and out of bounds fields.
+     */
+    fun getFieldByIndex(i: Int, fieldsNumber: Int = 12, extraFieldsNumber: Int? = null): Any? {
+        val actualExtraFieldsNumber = extraFieldsNumber ?: extraFields?.size ?: 0
         return when {
-            i >= fieldsNumber + extraFieldsNumber -> null
-            i >= fieldsNumber -> extraFields?.get(i - fieldsNumber)
+            i >= fieldsNumber + actualExtraFieldsNumber -> null
+            i >= fieldsNumber -> extraFields?.let {
+                if (i - fieldsNumber < it.size) it[i - fieldsNumber] else null
+            }
             else -> when (i) {
                 0 -> start
                 1 -> end

--- a/src/main/kotlin/org/jetbrains/bio/big/Bed.kt
+++ b/src/main/kotlin/org/jetbrains/bio/big/Bed.kt
@@ -371,9 +371,9 @@ data class ExtendedBedEntry(
                 if (i - fieldsNumber < it.size) it[i - fieldsNumber] else null
             }
             else -> when (i) {
-                0 -> start
-                1 -> end
-                2 -> chrom
+                0 -> chrom
+                1 -> start
+                2 -> end
                 3 -> name
                 4 -> score
                 5 -> strand

--- a/src/main/kotlin/org/jetbrains/bio/big/Bed.kt
+++ b/src/main/kotlin/org/jetbrains/bio/big/Bed.kt
@@ -358,7 +358,7 @@ data class ExtendedBedEntry(
         return rest
     }
 
-    operator fun get(i: Int, fieldsNumber: Int, extraFieldsNumber: Int): Any? {
+    fun getFieldByIndex(i: Int, fieldsNumber: Int, extraFieldsNumber: Int): Any? {
         return when {
             i >= fieldsNumber + extraFieldsNumber -> null
             i >= fieldsNumber -> extraFields?.get(i - fieldsNumber)

--- a/src/main/kotlin/org/jetbrains/bio/big/Bed.kt
+++ b/src/main/kotlin/org/jetbrains/bio/big/Bed.kt
@@ -363,7 +363,7 @@ data class ExtendedBedEntry(
      * it doesn't actually know which field is i-th, so we have to provide [fieldsNumber] and [extraFieldsNumber].
      * Returns an instance of a correct type ([Int], [String] etc.) or null for missing and out of bounds fields.
      */
-    fun getFieldByIndex(i: Int, fieldsNumber: Int = 12, extraFieldsNumber: Int? = null): Any? {
+    fun getField(i: Int, fieldsNumber: Int = 12, extraFieldsNumber: Int? = null): Any? {
         val actualExtraFieldsNumber = extraFieldsNumber ?: extraFields?.size ?: 0
         return when {
             i >= fieldsNumber + actualExtraFieldsNumber -> null

--- a/src/main/kotlin/org/jetbrains/bio/big/Bed.kt
+++ b/src/main/kotlin/org/jetbrains/bio/big/Bed.kt
@@ -357,4 +357,26 @@ data class ExtendedBedEntry(
         }
         return rest
     }
+
+    operator fun get(i: Int, fieldsNumber: Int, extraFieldsNumber: Int): Any? {
+        return when {
+            i >= fieldsNumber + extraFieldsNumber -> null
+            i >= fieldsNumber -> extraFields?.get(i - fieldsNumber)
+            else -> when (i) {
+                0 -> start
+                1 -> end
+                2 -> chrom
+                3 -> name
+                4 -> score
+                5 -> strand
+                6 -> thickStart
+                7 -> thickEnd
+                8 -> itemRgb
+                9 -> blockCount
+                10 -> blockSizes
+                11 -> blockStarts
+                else -> null // should never happen
+            }
+        }
+    }
 }

--- a/src/test/kotlin/org/jetbrains/bio/big/BedEntryTest.kt
+++ b/src/test/kotlin/org/jetbrains/bio/big/BedEntryTest.kt
@@ -319,7 +319,7 @@ class BedEntryTest {
     fun getFieldBed12p2() = assertGet(12, 2)
 
     private fun assertGet(fieldsNumber: Int = 12, extraFieldsNumber: Int? = null) {
-        val actualFields = (0 until 14).map { e.getFieldByIndex(it, fieldsNumber, extraFieldsNumber) }
+        val actualFields = (0 until 14).map { e.getField(it, fieldsNumber, extraFieldsNumber) }
         val realExtraFieldsNumber = extraFieldsNumber ?: 2
         val expectedFields = listOf<Any?>(
             "chr1", 10, 30, "be", 5.toShort(), '+', 15, 25, Color(15, 16, 17).rgb,

--- a/src/test/kotlin/org/jetbrains/bio/big/BedEntryTest.kt
+++ b/src/test/kotlin/org/jetbrains/bio/big/BedEntryTest.kt
@@ -4,6 +4,7 @@ import org.junit.Assert
 import org.junit.Test
 import java.awt.Color
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * @author Roman.Chernyatchik
@@ -285,6 +286,65 @@ class BedEntryTest {
             ExtendedBedEntry("chr1", 1, 100, extraFields = arrayOf(".", ".")),
             BedEntry("chr1", 1, 100, ".\t.\t.\t.\t.\t.\t.\t.\t.\t.\t.").unpack()
         )
+    }
+
+    @Test
+    fun getField() = assertGet()
+
+    @Test
+    fun getFieldBed3p0() = assertGet(3, 0)
+
+    @Test
+    fun getFieldBed3pAll() = assertGet(3)
+
+    @Test
+    fun getFieldBed6p0() = assertGet(6, 0)
+
+    @Test
+    fun getFieldBed6p1() = assertGet(6, 1)
+
+    @Test
+    fun getFieldBed6p2() = assertGet(6, 2)
+
+    @Test
+    fun getFieldBed6pAll() = assertGet(6)
+
+    @Test
+    fun getFieldBed9p2() = assertGet(9, 2)
+
+    @Test
+    fun getFieldBed12p0() = assertGet(12, 0)
+
+    @Test
+    fun getFieldBed12p2() = assertGet(12, 2)
+
+    private fun assertGet(fieldsNumber: Int = 12, extraFieldsNumber: Int? = null) {
+        val actualFields = (0 until 14).map { e.getFieldByIndex(it, fieldsNumber, extraFieldsNumber) }
+        val realExtraFieldsNumber = extraFieldsNumber ?: 2
+        val expectedFields = listOf<Any?>(
+            "chr1", 10, 30, "be", 5.toShort(), '+', 15, 25, Color(15, 16, 17).rgb,
+            2, intArrayOf(4, 5), intArrayOf(11, 20)
+        ).slice(0 until fieldsNumber).toMutableList()
+        expectedFields.addAll(listOf("val1", "4.55").slice(0 until realExtraFieldsNumber))
+        // out-of-bounds fields are always null
+        (fieldsNumber + realExtraFieldsNumber until 14).forEach { expectedFields.add(null) }
+        for (i in 0 until 14) {
+            val expectedField = expectedFields[i]
+            val actualField = actualFields[i]
+            // a special case for IntArray, since assertEquals is not array-friendly
+            if (expectedField is IntArray) {
+                assertTrue(
+                    actualField is IntArray,
+                    "Expected IntArray as field $i, got ${actualField?.javaClass ?: "null"}"
+                )
+                assertEquals(
+                    expectedField.toList(), (actualField as IntArray).toList(),
+                    "Assertion error when reading field $i"
+                )
+            } else {
+                assertEquals(expectedField, actualField, "Assertion error when reading field $i")
+            }
+        }
     }
 
     private fun assertPackAndRest(expected: BedEntry, e: ExtendedBedEntry, fieldsNumber: Byte, extraFieldsNumber: Int) {

--- a/src/test/kotlin/org/jetbrains/bio/big/BedEntryTest.kt
+++ b/src/test/kotlin/org/jetbrains/bio/big/BedEntryTest.kt
@@ -11,77 +11,72 @@ import kotlin.test.assertTrue
  */
 class BedEntryTest {
 
-    private val e = ExtendedBedEntry(
-        "chr1", 10, 30, "be", 5, '+', 15, 25,
-        Color(15, 16, 17).rgb, 2, intArrayOf(4, 5), intArrayOf(11, 20),
-        arrayOf("val1", "4.55")
-    )
-
     @Test fun pack() {
         val expected = BedEntry(
             "chr1", 10, 30, "be\t5\t+\t15\t25\t15,16,17\t2\t4,5\t11,20\tval1\t4.55"
         )
-        assertEquals(expected, e.pack())
-        assertEquals(expected.rest.split("\t"), e.rest())
+        assertEquals(expected, BED_ENTRY_12_P_2.pack())
+        assertEquals(expected.rest.split("\t"), BED_ENTRY_12_P_2.rest())
     }
 
     @Test fun packBed3p0() {
         val expected = BedEntry("chr1", 10, 30, "")
-        assertPackAndRest(expected, e, 3, 0)
+        assertPackAndRest(expected, BED_ENTRY_12_P_2, 3, 0)
     }
 
     @Test fun packBed3pAll() {
         val expected = BedEntry("chr1", 10, 30, "val1\t4.55")
-        assertEquals(expected, e.pack(fieldsNumber = 3))
-        assertEquals(expected.rest.split("\t"), e.rest(fieldsNumber = 3))
+        assertEquals(expected, BED_ENTRY_12_P_2.pack(fieldsNumber = 3))
+        assertEquals(expected.rest.split("\t"), BED_ENTRY_12_P_2.rest(fieldsNumber = 3))
     }
 
     @Test fun packBed6pAll() {
         val expected = BedEntry("chr1", 10, 30, "be\t5\t+\tval1\t4.55")
-        assertEquals(expected, e.pack(fieldsNumber = 6))
-        assertEquals(expected.rest.split("\t"), e.rest(fieldsNumber = 6))
+        assertEquals(expected, BED_ENTRY_12_P_2.pack(fieldsNumber = 6))
+        assertEquals(expected.rest.split("\t"), BED_ENTRY_12_P_2.rest(fieldsNumber = 6))
     }
 
     @Test fun packBed6p0() = assertPackAndRest(
-        BedEntry("chr1", 10, 30, "be\t5\t+"), e, 6, 0
+        BedEntry("chr1", 10, 30, "be\t5\t+"), BED_ENTRY_12_P_2, 6, 0
     )
 
     @Test fun packBed6p1() = assertPackAndRest(
-        BedEntry("chr1", 10, 30, "be\t5\t+\tval1"), e, 6, 1
+        BedEntry("chr1", 10, 30, "be\t5\t+\tval1"), BED_ENTRY_12_P_2, 6, 1
     )
 
     @Test fun packBed6p2() = assertPackAndRest(
-        BedEntry("chr1", 10, 30, "be\t5\t+\tval1\t4.55"), e, 6, 2
+        BedEntry("chr1", 10, 30, "be\t5\t+\tval1\t4.55"), BED_ENTRY_12_P_2, 6, 2
     )
 
     @Test fun packBed9p2() = assertPackAndRest(
-        BedEntry("chr1", 10, 30, "be\t5\t+\t15\t25\t15,16,17\tval1\t4.55"), e,
+        BedEntry("chr1", 10, 30, "be\t5\t+\t15\t25\t15,16,17\tval1\t4.55"), BED_ENTRY_12_P_2,
         9, 2
     )
 
     @Test fun packBed12p0() = assertPackAndRest(
-        BedEntry("chr1", 10, 30, "be\t5\t+\t15\t25\t15,16,17\t2\t4,5\t11,20"), e,
+        BedEntry("chr1", 10, 30, "be\t5\t+\t15\t25\t15,16,17\t2\t4,5\t11,20"), BED_ENTRY_12_P_2,
         12, 0
     )
 
     @Test fun packBed12p2() = assertPackAndRest(
-        BedEntry("chr1", 10, 30, "be\t5\t+\t15\t25\t15,16,17\t2\t4,5\t11,20\tval1\t4.55"), e,
+        BedEntry("chr1", 10, 30, "be\t5\t+\t15\t25\t15,16,17\t2\t4,5\t11,20\tval1\t4.55"),
+        BED_ENTRY_12_P_2,
         12, 2
     )
 
     @Test(expected = IllegalStateException::class)
     fun packBed2() {
-        e.pack(fieldsNumber = 2)
+        BED_ENTRY_12_P_2.pack(fieldsNumber = 2)
     }
 
     @Test(expected = IllegalStateException::class)
     fun packBed13() {
-        e.pack(fieldsNumber = 13)
+        BED_ENTRY_12_P_2.pack(fieldsNumber = 13)
     }
 
     @Test fun packBedCustomDelimiter() {
         assertEquals(BedEntry("chr1", 10, 30, "be;5;+;val1;4.55"),
-            e.pack(fieldsNumber = 6, extraFieldsNumber = 2, delimiter = ';'))
+            BED_ENTRY_12_P_2.pack(fieldsNumber = 6, extraFieldsNumber = 2, delimiter = ';'))
     }
 
     @Test(expected = IllegalStateException::class)
@@ -319,7 +314,7 @@ class BedEntryTest {
     fun getFieldBed12p2() = assertGet(12, 2)
 
     private fun assertGet(fieldsNumber: Int = 12, extraFieldsNumber: Int? = null) {
-        val actualFields = (0 until 14).map { e.getField(it, fieldsNumber, extraFieldsNumber) }
+        val actualFields = (0 until 14).map { BED_ENTRY_12_P_2.getField(it, fieldsNumber, extraFieldsNumber) }
         val realExtraFieldsNumber = extraFieldsNumber ?: 2
         val expectedFields = listOf<Any?>(
             "chr1", 10, 30, "be", 5.toShort(), '+', 15, 25, Color(15, 16, 17).rgb,
@@ -362,6 +357,14 @@ class BedEntryTest {
         Assert.assertArrayEquals(
             toTypedArray,
             e.rest(fieldsNumber = fieldsNumber, extraFieldsNumber = extraFieldsNumber).toTypedArray()
+        )
+    }
+
+    companion object {
+        val BED_ENTRY_12_P_2 = ExtendedBedEntry(
+            "chr1", 10, 30, "be", 5, '+', 15, 25,
+            Color(15, 16, 17).rgb, 2, intArrayOf(4, 5), intArrayOf(11, 20),
+            arrayOf("val1", "4.55")
         )
     }
 }

--- a/src/test/kotlin/org/jetbrains/bio/big/BedEntryTest.kt
+++ b/src/test/kotlin/org/jetbrains/bio/big/BedEntryTest.kt
@@ -9,172 +9,120 @@ import kotlin.test.assertEquals
  * @author Roman.Chernyatchik
  */
 class BedEntryTest {
-    @Test fun pack() {
-        val e = ExtendedBedEntry(
-                "chr1", 10, 30, "be", 5, '+', 15, 25,
-                Color(15, 16, 17).rgb, 2, intArrayOf(4, 5), intArrayOf(11, 20),
-                arrayOf("val1", "4.55"))
 
-        val expected = BedEntry("chr1", 10, 30, "be\t5\t+\t15\t25\t15,16,17\t2\t4,5\t11,20\tval1\t4.55")
+    private val e = ExtendedBedEntry(
+        "chr1", 10, 30, "be", 5, '+', 15, 25,
+        Color(15, 16, 17).rgb, 2, intArrayOf(4, 5), intArrayOf(11, 20),
+        arrayOf("val1", "4.55")
+    )
+
+    @Test fun pack() {
+        val expected = BedEntry(
+            "chr1", 10, 30, "be\t5\t+\t15\t25\t15,16,17\t2\t4,5\t11,20\tval1\t4.55"
+        )
         assertEquals(expected, e.pack())
         assertEquals(expected.rest.split("\t"), e.rest())
     }
 
     @Test fun packBed3p0() {
-        val e = ExtendedBedEntry(
-                "chr1", 10, 30, "be", 5, '+', 15, 25,
-                Color(15, 16, 17).rgb, 2, intArrayOf(4, 5), intArrayOf(11, 20),
-                arrayOf("val1", "4.55"))
-
         val expected = BedEntry("chr1", 10, 30, "")
         assertPackAndRest(expected, e, 3, 0)
-
     }
 
     @Test fun packBed3pAll() {
-        val e = ExtendedBedEntry(
-                "chr1", 10, 30, "be", 5, '+', 15, 25,
-                Color(15, 16, 17).rgb, 2, intArrayOf(4, 5), intArrayOf(11, 20),
-                arrayOf("val1", "4.55"))
-
         val expected = BedEntry("chr1", 10, 30, "val1\t4.55")
-
         assertEquals(expected, e.pack(fieldsNumber = 3))
         assertEquals(expected.rest.split("\t"), e.rest(fieldsNumber = 3))
     }
 
     @Test fun packBed6pAll() {
-        val e = ExtendedBedEntry(
-                "chr1", 10, 30, "be", 5, '+', 15, 25,
-                Color(15, 16, 17).rgb, 2, intArrayOf(4, 5), intArrayOf(11, 20),
-                arrayOf("val1", "4.55"))
-
         val expected = BedEntry("chr1", 10, 30, "be\t5\t+\tval1\t4.55")
         assertEquals(expected, e.pack(fieldsNumber = 6))
         assertEquals(expected.rest.split("\t"), e.rest(fieldsNumber = 6))
     }
 
-    @Test fun packBed6p0() {
-        val e = ExtendedBedEntry(
-                "chr1", 10, 30, "be", 5, '+', 15, 25,
-                Color(15, 16, 17).rgb, 2, intArrayOf(4, 5), intArrayOf(11, 20),
-                arrayOf("val1", "4.55"))
+    @Test fun packBed6p0() = assertPackAndRest(
+        BedEntry("chr1", 10, 30, "be\t5\t+"), e, 6, 0
+    )
 
-        assertPackAndRest(BedEntry("chr1", 10, 30, "be\t5\t+"), e, 6, 0)
-    }
+    @Test fun packBed6p1() = assertPackAndRest(
+        BedEntry("chr1", 10, 30, "be\t5\t+\tval1"), e, 6, 1
+    )
 
-    @Test fun packBed6p1() {
-        val e = ExtendedBedEntry(
-                "chr1", 10, 30, "be", 5, '+', 15, 25,
-                Color(15, 16, 17).rgb, 2, intArrayOf(4, 5), intArrayOf(11, 20),
-                arrayOf("val1", "4.55"))
+    @Test fun packBed6p2() = assertPackAndRest(
+        BedEntry("chr1", 10, 30, "be\t5\t+\tval1\t4.55"), e, 6, 2
+    )
 
-        assertPackAndRest(BedEntry("chr1", 10, 30, "be\t5\t+\tval1"), e, 6, 1)
-    }
+    @Test fun packBed9p2() = assertPackAndRest(
+        BedEntry("chr1", 10, 30, "be\t5\t+\t15\t25\t15,16,17\tval1\t4.55"), e,
+        9, 2
+    )
 
-    @Test fun packBed6p2() {
-        val e = ExtendedBedEntry(
-                "chr1", 10, 30, "be", 5, '+', 15, 25,
-                Color(15, 16, 17).rgb, 2, intArrayOf(4, 5), intArrayOf(11, 20),
-                arrayOf("val1", "4.55"))
+    @Test fun packBed12p0() = assertPackAndRest(
+        BedEntry("chr1", 10, 30, "be\t5\t+\t15\t25\t15,16,17\t2\t4,5\t11,20"), e,
+        12, 0
+    )
 
-        assertPackAndRest(BedEntry("chr1", 10, 30, "be\t5\t+\tval1\t4.55"), e, 6, 2)
-    }
-
-    @Test fun packBed9p2() {
-        val e = ExtendedBedEntry(
-                "chr1", 10, 30, "be", 5, '+', 15, 25,
-                Color(15, 16, 17).rgb, 2, intArrayOf(4, 5), intArrayOf(11, 20),
-                arrayOf("val1", "4.55"))
-
-        assertPackAndRest(BedEntry("chr1", 10, 30, "be\t5\t+\t15\t25\t15,16,17\tval1\t4.55"), e, 9, 2)
-    }
-
-    @Test fun packBed12p0() {
-        val e = ExtendedBedEntry(
-                "chr1", 10, 30, "be", 5, '+', 15, 25,
-                Color(15, 16, 17).rgb, 2, intArrayOf(4, 5), intArrayOf(11, 20),
-                arrayOf("val1", "4.55"))
-
-        assertPackAndRest(BedEntry("chr1", 10, 30, "be\t5\t+\t15\t25\t15,16,17\t2\t4,5\t11,20"), e, 12, 0)
-    }
-
-    @Test fun packBed12p2() {
-        val e = ExtendedBedEntry(
-                "chr1", 10, 30, "be", 5, '+', 15, 25,
-                Color(15, 16, 17).rgb, 2, intArrayOf(4, 5), intArrayOf(11, 20),
-                arrayOf("val1", "4.55"))
-
-        assertPackAndRest(BedEntry("chr1", 10, 30, "be\t5\t+\t15\t25\t15,16,17\t2\t4,5\t11,20\tval1\t4.55"), e, 12, 2)
-    }
+    @Test fun packBed12p2() = assertPackAndRest(
+        BedEntry("chr1", 10, 30, "be\t5\t+\t15\t25\t15,16,17\t2\t4,5\t11,20\tval1\t4.55"), e,
+        12, 2
+    )
 
     @Test(expected = IllegalStateException::class)
     fun packBed2() {
-        val e = ExtendedBedEntry(
-                "chr1", 10, 30, "be", 5, '+', 15, 25,
-                Color(15, 16, 17).rgb, 2, intArrayOf(4, 5), intArrayOf(11, 20),
-                arrayOf("val1", "4.55"))
         e.pack(fieldsNumber = 2)
     }
 
     @Test(expected = IllegalStateException::class)
     fun packBed13() {
-        val e = ExtendedBedEntry(
-                "chr1", 10, 30, "be", 5, '+', 15, 25,
-                Color(15, 16, 17).rgb, 2, intArrayOf(4, 5), intArrayOf(11, 20),
-                arrayOf("val1", "4.55"))
         e.pack(fieldsNumber = 13)
     }
 
     @Test fun packBedCustomDelimiter() {
-        val e = ExtendedBedEntry(
-                "chr1", 10, 30, "be", 5, '+', 15, 25,
-                Color(15, 16, 17).rgb, 2, intArrayOf(4, 5), intArrayOf(11, 20),
-                arrayOf("val1", "4.55"))
-
         assertEquals(BedEntry("chr1", 10, 30, "be;5;+;val1;4.55"),
-                     e.pack(fieldsNumber = 6, extraFieldsNumber = 2, delimiter = ';'))
+            e.pack(fieldsNumber = 6, extraFieldsNumber = 2, delimiter = ';'))
     }
 
     @Test(expected = IllegalStateException::class)
     fun packWrongSizes() {
         ExtendedBedEntry("chr1", 10, 30, blockCount = 2,
-                         blockSizes = intArrayOf(4), blockStarts = intArrayOf(11, 20)
+            blockSizes = intArrayOf(4), blockStarts = intArrayOf(11, 20)
         ).pack()
     }
 
     @Test(expected = IllegalStateException::class)
     fun packWrongStarts() {
         ExtendedBedEntry("chr1", 10, 30, blockCount = 2,
-                                 blockSizes = intArrayOf(4, 5), blockStarts = intArrayOf(11)
+            blockSizes = intArrayOf(4, 5), blockStarts = intArrayOf(11)
         ).pack()
     }
 
     @Test fun packNoColor() {
-        val e = ExtendedBedEntry("chr1", 10, 30, itemRgb = 0)
-
-        assertPackAndRest(BedEntry("chr1", 10, 30, ".\t0\t.\t0\t0\t0"), e, 9, 0)
-
+        val e4 = ExtendedBedEntry("chr1", 10, 30, itemRgb = 0)
+        assertPackAndRest(
+            BedEntry("chr1", 10, 30, ".\t0\t.\t0\t0\t0"), e4, 9, 0
+        )
     }
 
     @Test fun packNoBlocks() {
-        val e = ExtendedBedEntry("chr1", 10, 30)
-
-        assertPackAndRest(BedEntry("chr1", 10, 30, ".\t0\t.\t0\t0\t0\t0\t.\t."), e, 12, 0)
-
+        val e3 = ExtendedBedEntry("chr1", 10, 30)
+        assertPackAndRest(
+            BedEntry("chr1", 10, 30, ".\t0\t.\t0\t0\t0\t0\t.\t."), e3,
+            12, 0
+        )
     }
 
     @Test
     fun unpack() {
         val bedEntries = listOf(
-                ExtendedBedEntry("chr1", 1, 100, ".", 0, '+',
-                                 15, 25,
-                                 Color(15, 16, 17).rgb, 2, intArrayOf(4, 5), intArrayOf(11, 20),
-                                 extraFields = arrayOf("34.56398", "-1.00000", "4.91755", "240")),
-                ExtendedBedEntry("chr1", 200, 300, ".", 800, '.',
-                                 20, 22,
-                                 0, 0,
-                                 extraFields = arrayOf("193.07668", "-1.00000", "4.91755", "171"))
+            ExtendedBedEntry("chr1", 1, 100, ".", 0, '+',
+                15, 25,
+                Color(15, 16, 17).rgb, 2, intArrayOf(4, 5), intArrayOf(11, 20),
+                extraFields = arrayOf("34.56398", "-1.00000", "4.91755", "240")),
+            ExtendedBedEntry("chr1", 200, 300, ".", 800, '.',
+                20, 22,
+                0, 0,
+                extraFields = arrayOf("193.07668", "-1.00000", "4.91755", "171"))
         )
         assertEquals(bedEntries, bedEntries.map { it.pack().unpack(extraFieldsNumber = 4) })
     }
@@ -183,97 +131,109 @@ class BedEntryTest {
         val bedEntry = BedEntry("chr1", 1, 100, "")
         val expected = ExtendedBedEntry("chr1", 1, 100)
         val actual = bedEntry.unpack(fieldsNumber = 3)
-        assertEquals(expected,
-                     actual
-        )
+        assertEquals(expected, actual)
     }
 
     @Test fun unpackBed3as12() {
         val bedEntry = BedEntry("chr1", 1, 100, "")
-        assertEquals(ExtendedBedEntry("chr1", 1, 100),
-                     bedEntry.unpack(fieldsNumber = 12)
+        assertEquals(
+            ExtendedBedEntry("chr1", 1, 100), bedEntry.unpack(fieldsNumber = 12)
         )
     }
 
     @Test fun unpackBed3p0() {
         val bedEntry = BedEntry("chr1", 1, 100, ".\t4\t+\t34.56398\t-1.00000\t4.91755\t240")
-        assertEquals(ExtendedBedEntry("chr1", 1, 100),
-                     bedEntry.unpack(fieldsNumber = 3, extraFieldsNumber = 0)
+        assertEquals(
+            ExtendedBedEntry("chr1", 1, 100), bedEntry.unpack(fieldsNumber = 3, extraFieldsNumber = 0)
         )
     }
 
     @Test fun unpackBed3p4Partial() {
         val bedEntry = BedEntry("chr1", 1, 100, ".\t4\t+\t34.56398\t-1.00000\t4.91755\t240")
-        assertEquals(ExtendedBedEntry("chr1", 1, 100,
-                                      extraFields = arrayOf(".", "4", "+", "34.56398")),
-                     bedEntry.unpack(fieldsNumber = 3, extraFieldsNumber = 4)
+        assertEquals(
+            ExtendedBedEntry("chr1", 1, 100, extraFields = arrayOf(".", "4", "+", "34.56398")),
+            bedEntry.unpack(fieldsNumber = 3, extraFieldsNumber = 4)
         )
     }
 
     @Test fun unpackBed3p4() {
         val bedEntry = BedEntry("chr1", 1, 100, "34.56398\t-1.00000\t4.91755\t240")
-        assertEquals(ExtendedBedEntry("chr1", 1, 100,
-                                      extraFields = arrayOf("34.56398", "-1.00000", "4.91755", "240")),
-                     bedEntry.unpack(fieldsNumber = 3, extraFieldsNumber = 4)
+        assertEquals(
+            ExtendedBedEntry(
+                "chr1", 1, 100,
+                extraFields = arrayOf("34.56398", "-1.00000", "4.91755", "240")
+            ),
+            bedEntry.unpack(fieldsNumber = 3, extraFieldsNumber = 4)
         )
     }
 
     @Test fun unpackBed6p4() {
         val bedEntry = BedEntry("chr1", 1, 100, ".\t4\t+\t34.56398\t-1.00000\t4.91755\t240")
-        assertEquals(ExtendedBedEntry("chr1", 1, 100, ".", 4, '+',
-                                      extraFields = arrayOf("34.56398", "-1.00000", "4.91755", "240")),
-                     bedEntry.unpack(fieldsNumber = 6, extraFieldsNumber = 4)
+        assertEquals(
+            ExtendedBedEntry(
+                "chr1", 1, 100, ".", 4, '+',
+                extraFields = arrayOf("34.56398", "-1.00000", "4.91755", "240")
+            ),
+            bedEntry.unpack(fieldsNumber = 6, extraFieldsNumber = 4)
         )
     }
 
     @Test fun unpackBedEmptyName() {
         val bedEntry = BedEntry("chr1", 1, 100, "\t4\t+")
-        assertEquals(ExtendedBedEntry("chr1", 1, 100, ".", 4, '+'),
-                     bedEntry.unpack(fieldsNumber = 6)
+        assertEquals(
+            ExtendedBedEntry("chr1", 1, 100, ".", 4, '+'),
+            bedEntry.unpack(fieldsNumber = 6)
         )
     }
 
     @Test fun unpackBedEmptyExtraFields1() {
         val bedEntry = BedEntry("chr1", 1, 100, "")
-        assertEquals(ExtendedBedEntry("chr1", 1, 100),
-                     bedEntry.unpack(fieldsNumber = 3)
+        assertEquals(
+            ExtendedBedEntry("chr1", 1, 100), bedEntry.unpack(fieldsNumber = 3)
         )
     }
 
     @Test fun unpackBedEmptyExtraFields2() {
         val bedEntry = BedEntry("chr1", 1, 100, "foo\t")
-        assertEquals(ExtendedBedEntry("chr1", 1, 100, "foo"),
-                     bedEntry.unpack(fieldsNumber = 4)
+        assertEquals(
+            ExtendedBedEntry("chr1", 1, 100, "foo"), bedEntry.unpack(fieldsNumber = 4)
         )
     }
 
     @Test fun unpackMoreExtraFieldsThanNeeded() {
         val bedEntry = BedEntry("chr1", 1, 100, ".\t4\t+\t34.56398\t-1.00000")
-        assertEquals(ExtendedBedEntry("chr1", 1, 100, ".", 4, '+',
-                                      extraFields = arrayOf("34.56398", "-1.00000")),
-                     bedEntry.unpack(fieldsNumber = 6, extraFieldsNumber = 4)
+        assertEquals(
+            ExtendedBedEntry(
+                "chr1", 1, 100, ".", 4, '+',
+                extraFields = arrayOf("34.56398", "-1.00000")
+            ),
+            bedEntry.unpack(fieldsNumber = 6, extraFieldsNumber = 4)
         )
     }
 
     @Test fun unpackLessExtraFieldsThanNeeded() {
         val bedEntry = BedEntry("chr1", 1, 100, ".\t4\t+")
-        assertEquals(ExtendedBedEntry("chr1", 1, 100, ".",
-                                      extraFields = arrayOf("4", "+")),
-                     bedEntry.unpack(fieldsNumber = 4, extraFieldsNumber = 4)
+        assertEquals(
+            ExtendedBedEntry("chr1", 1, 100, ".", extraFields = arrayOf("4", "+")),
+            bedEntry.unpack(fieldsNumber = 4, extraFieldsNumber = 4)
         )
     }
     @Test fun unpackNoExtraFieldsWhenNeeded() {
         val bedEntry = BedEntry("chr1", 1, 100, "\t4\t+")
-        assertEquals(ExtendedBedEntry("chr1", 1, 100, ".", 4, '+'),
-                     bedEntry.unpack(fieldsNumber = 6, extraFieldsNumber = 1)
+        assertEquals(
+            ExtendedBedEntry("chr1", 1, 100, ".", 4, '+'),
+            bedEntry.unpack(fieldsNumber = 6, extraFieldsNumber = 1)
         )
     }
 
     @Test fun unpackBed4pAll() {
         val bedEntry = BedEntry("chr1", 1, 100, "foo\t34.56398\t-1.00000\t4.91755\t240")
-        assertEquals(ExtendedBedEntry("chr1", 1, 100, "foo",
-                                      extraFields = arrayOf("34.56398", "-1.00000", "4.91755", "240")),
-                     bedEntry.unpack(fieldsNumber = 4)
+        assertEquals(
+            ExtendedBedEntry(
+                "chr1", 1, 100, "foo",
+                extraFields = arrayOf("34.56398", "-1.00000", "4.91755", "240")
+            ),
+            bedEntry.unpack(fieldsNumber = 4)
         )
     }
 
@@ -289,35 +249,48 @@ class BedEntryTest {
 
     @Test fun unpackBed3p4CustomDelimiter() {
         val bedEntry = BedEntry("chr1", 1, 100, "34.56398;-1.00000;4.91755;240")
-        assertEquals(ExtendedBedEntry("chr1", 1, 100,
-                                      extraFields = arrayOf("34.56398", "-1.00000", "4.91755", "240")),
-                     bedEntry.unpack(fieldsNumber = 3, extraFieldsNumber = 4, delimiter = ';')
+        assertEquals(
+            ExtendedBedEntry(
+                "chr1", 1, 100,
+                extraFields = arrayOf("34.56398", "-1.00000", "4.91755", "240")
+            ),
+            bedEntry.unpack(fieldsNumber = 3, extraFieldsNumber = 4, delimiter = ';')
         )
     }
 
     @Test fun unpackBed3p4OmitEmptyStrings() {
         val bedEntry = BedEntry("chr1", 1, 100, "34.56398    -1.00000    4.91755    240")
-        assertEquals(ExtendedBedEntry("chr1", 1, 100,
-                                      extraFields = arrayOf("34.56398", "-1.00000", "4.91755", "240")),
-                     bedEntry.unpack(fieldsNumber = 3, extraFieldsNumber = 4,
-                                     delimiter = ' ', omitEmptyStrings = true)
+        assertEquals(
+            ExtendedBedEntry(
+                "chr1", 1, 100,
+                extraFields = arrayOf("34.56398", "-1.00000", "4.91755", "240")
+            ),
+            bedEntry.unpack(
+                fieldsNumber = 3, extraFieldsNumber = 4, delimiter = ' ', omitEmptyStrings = true
+            )
         )
     }
 
     @Test fun unpackBedDotDefaultValues() {
-        assertEquals(ExtendedBedEntry("chr1", 1, 100),
-                     BedEntry("chr1", 1, 100, ".\t.\t.\t.\t.\t.\t.\t.\t.").unpack())
+        assertEquals(
+            ExtendedBedEntry("chr1", 1, 100),
+            BedEntry("chr1", 1, 100, ".\t.\t.\t.\t.\t.\t.\t.\t.").unpack()
+        )
 
-        assertEquals(ExtendedBedEntry("chr1", 1, 100, extraFields = arrayOf(".")),
-                     BedEntry("chr1", 1, 100, ".\t.\t.\t.\t.\t.\t.\t.\t.\t.").unpack())
-        assertEquals(ExtendedBedEntry("chr1", 1, 100, extraFields = arrayOf(".", ".")),
-                     BedEntry("chr1", 1, 100, ".\t.\t.\t.\t.\t.\t.\t.\t.\t.\t.").unpack())
+        assertEquals(
+            ExtendedBedEntry("chr1", 1, 100, extraFields = arrayOf(".")),
+            BedEntry("chr1", 1, 100, ".\t.\t.\t.\t.\t.\t.\t.\t.\t.").unpack()
+        )
+        assertEquals(
+            ExtendedBedEntry("chr1", 1, 100, extraFields = arrayOf(".", ".")),
+            BedEntry("chr1", 1, 100, ".\t.\t.\t.\t.\t.\t.\t.\t.\t.\t.").unpack()
+        )
     }
 
     private fun assertPackAndRest(expected: BedEntry, e: ExtendedBedEntry, fieldsNumber: Byte, extraFieldsNumber: Int) {
         assertEquals(
-                expected,
-                e.pack(fieldsNumber = fieldsNumber, extraFieldsNumber = extraFieldsNumber)
+            expected,
+            e.pack(fieldsNumber = fieldsNumber, extraFieldsNumber = extraFieldsNumber)
         )
         val toTypedArray = expected.rest.let {
             if (it.isEmpty()) {
@@ -327,8 +300,8 @@ class BedEntryTest {
             }
         }
         Assert.assertArrayEquals(
-                toTypedArray,
-                e.rest(fieldsNumber = fieldsNumber, extraFieldsNumber = extraFieldsNumber).toTypedArray()
+            toTypedArray,
+            e.rest(fieldsNumber = fieldsNumber, extraFieldsNumber = extraFieldsNumber).toTypedArray()
         )
     }
 }


### PR DESCRIPTION
Usage:
```Kotlin
val e: ExtendedBedEntry
...
e.getField(3, fieldsNumber = 12, extraFieldsNumber = 0) // returns "name" field as String or null if it's not present
e.getField(4, fieldsNumber = 6, extraFieldsNumber = 3) // returns "score" field as Short or null if it's not present
e.getField(7, fieldsNumber = 6, extraFieldsNumber = 3) // returns the second extra field as String or null if it's not present
```

New functionality is covered by tests.
The method was suggested in another pull request review in `epigenome`.