### PR TITLE
Replace BED score type with Int

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,7 +8,7 @@ Version 0.8.5
 
 Released on XXXXXX
 
-New
+Fixed
 - `ExtendedBedEntry.score` is now Int instead of Short. The reason for this is that many
   BED file providers (e.g. MACS2, SICER) don't respect the UCSC standard which limits the score
   to 0..1000 range, and we want to be able to parse those files.

--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,16 @@ big Changelog
 
 Here you can see the full list of changes between each big release.
 
+Version 0.8.5
+-------------
+
+Released on XXXXXX
+
+New
+- `ExtendedBedEntry.score` is now Int instead of Short. The reason for this is that many
+  BED file providers (e.g. MACS2, SICER) don't respect the UCSC standard which limits the score
+  to 0..1000 range, and we want to be able to parse those files.
+
 Version 0.8.4
 -------------
 

--- a/src/main/kotlin/org/jetbrains/bio/big/Bed.kt
+++ b/src/main/kotlin/org/jetbrains/bio/big/Bed.kt
@@ -60,7 +60,8 @@ data class BedEntry(
      * @param omitEmptyStrings Treat several consecutive separators as one
      */
     fun unpack(
-            fieldsNumber: Byte = 12, extraFieldsNumber: Int? = null,
+            fieldsNumber: Byte = 12,
+            extraFieldsNumber: Int? = null,
             delimiter: Char = '\t',
             omitEmptyStrings: Boolean = false
     ): ExtendedBedEntry {

--- a/src/test/kotlin/org/jetbrains/bio/big/BedEntryTest.kt
+++ b/src/test/kotlin/org/jetbrains/bio/big/BedEntryTest.kt
@@ -174,6 +174,17 @@ class BedEntryTest {
         )
     }
 
+    @Test fun unpackBed6p4IntScore() {
+        val bedEntry = BedEntry("chr1", 1, 100, ".\t40000\t+\t34.56398\t-1.00000\t4.91755\t240")
+        assertEquals(
+            ExtendedBedEntry(
+                "chr1", 1, 100, ".", 40000, '+',
+                extraFields = arrayOf("34.56398", "-1.00000", "4.91755", "240")
+            ),
+            bedEntry.unpack(fieldsNumber = 6, extraFieldsNumber = 4)
+        )
+    }
+
     @Test fun unpackBedEmptyName() {
         val bedEntry = BedEntry("chr1", 1, 100, "\t4\t+")
         assertEquals(

--- a/src/test/kotlin/org/jetbrains/bio/big/BedEntryTest.kt
+++ b/src/test/kotlin/org/jetbrains/bio/big/BedEntryTest.kt
@@ -317,7 +317,7 @@ class BedEntryTest {
         val actualFields = (0 until 14).map { BED_ENTRY_12_P_2.getField(it, fieldsNumber, extraFieldsNumber) }
         val realExtraFieldsNumber = extraFieldsNumber ?: 2
         val expectedFields = listOf<Any?>(
-            "chr1", 10, 30, "be", 5.toShort(), '+', 15, 25, Color(15, 16, 17).rgb,
+            "chr1", 10, 30, "be", 5, '+', 15, 25, Color(15, 16, 17).rgb,
             2, intArrayOf(4, 5), intArrayOf(11, 20)
         ).slice(0 until fieldsNumber).toMutableList()
         expectedFields.addAll(listOf("val1", "4.55").slice(0 until realExtraFieldsNumber))


### PR DESCRIPTION
Currently it's Short, owing to the fact that UCSC defines BED score as an integer in range [0,1000]. The problem is that most BED providers don't respect these limits (MACS2 and SICER. to name a few).

I posit that our goal should be usability, not reliance to a standard no one implements, so changing score type to Int seems reasonable.

See issue https://github.com/JetBrains-Research/bioinf-commons/issues/2 as an inspiration for this PR.