### PR TITLE
reduce memory usage when computing summary

### DIFF
--- a/src/main/kotlin/org/jetbrains/bio/big/BigBed.kt
+++ b/src/main/kotlin/org/jetbrains/bio/big/BigBed.kt
@@ -25,7 +25,9 @@ class BigBedFile private constructor(
             numBins: Int,
             cancelledChecker: (() -> Unit)?
     ): Sequence<IndexedValue<BigSummary>> {
-        val coverage = query(input, query, overlaps = true, cancelledChecker = cancelledChecker).aggregate()
+        val coverage = query(input, query, overlaps = true, cancelledChecker = cancelledChecker)
+          .map {it.copy(rest="")}
+          .aggregate()
         var edge = 0
         return query.slice(numBins).mapIndexed { i, bin ->
             val summary = BigSummary()


### PR DESCRIPTION
previously all BedEntries where fully loaded into memory, but we need only chr,from,to to compute summary